### PR TITLE
Scan vulnerabilities and upload SARIF report

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -29,6 +29,8 @@ jobs:
           skip-upload: true
           package: cmd/
           fail-on-vuln: false
+        env:
+          DEBUG: "true"
 
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: gosec-results-report.sarif
+          sarif_file: gosec-results.sarif
 
   govulncheck:
     name: govulncheck

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,36 @@
+name: Security
+
+on:
+  pull_request:
+    branches:
+      - "*"
+    paths-ignore:
+      - 'doc/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'doc/**'
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      - name: Scan for Vulnerabilities in Code
+        uses: Templum/govulncheck-action@v0.0.8
+        with:
+          go-version: 1.19
+          vulncheck-version: latest
+          skip-upload: true
+          package: cmd/
+          fail-on-vuln: false
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: govulncheck-report.sarif

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -30,7 +30,7 @@ jobs:
           # G104: Errors not checked
           # G306: Expect WriteFile permissions to be 0600 or less
           # G307: Deferring unsafe method "Close"
-          args: -exclude=G104,G306,G307 -tests=false -exclude-dir=doc/ -fmt sarif -out gosec-results.sarif  ./...
+          args: -exclude=G104,G306,G307 -tests=false -exclude-dir=doc/ -no-fail -fmt sarif -out gosec-results.sarif  ./...
 
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.19
           vulncheck-version: latest
           skip-upload: true
-          package: cmd/
+          package: cmd/...
           fail-on-vuln: false
         env:
           DEBUG: "true"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -32,6 +32,12 @@ jobs:
         env:
           DEBUG: "true"
 
+      - name: Upload Raw Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: raw-report
+          path: raw-report.json
+
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -30,7 +30,12 @@ jobs:
           # G104: Errors not checked
           # G306: Expect WriteFile permissions to be 0600 or less
           # G307: Deferring unsafe method "Close"
-          args: -exclude=G104,G306,G307 -tests=false -exclude-dir=doc/  ./...
+          args: -exclude=G104,G306,G307 -tests=false -exclude-dir=doc/ -fmt sarif -out gosec-results.sarif  ./...
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: gosec-results-report.sarif
 
   govulncheck:
     name: govulncheck

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.19
           vulncheck-version: latest
           skip-upload: true
-          package: cmd/...
+          package: ./cmd/...
           fail-on-vuln: false
         env:
           DEBUG: "true"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -12,6 +12,9 @@ on:
     paths-ignore:
       - 'doc/**'
 
+env:
+  GO_VERSION: "1.19"
+
 jobs:
   govulncheck:
     name: govulncheck
@@ -24,19 +27,11 @@ jobs:
       - name: Scan for Vulnerabilities in Code
         uses: Templum/govulncheck-action@v0.0.8
         with:
-          go-version: 1.19
-          vulncheck-version: latest
+          package: ./cmd/
           skip-upload: true
-          package: ./cmd/...
           fail-on-vuln: false
-        env:
-          DEBUG: "true"
-
-      - name: Upload Raw Report
-        uses: actions/upload-artifact@v3
-        with:
-          name: raw-report
-          path: raw-report.json
+          vulncheck-version: latest
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -16,6 +16,22 @@ env:
   GO_VERSION: "1.19"
 
 jobs:
+  gosec:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@1af1d5bb49259b62e45c505db397dd2ada5d74f8 # v2.14.0
+        with:
+          # Ignoring:
+          # G104: Errors not checked
+          # G306: Expect WriteFile permissions to be 0600 or less
+          # G307: Deferring unsafe method "Close"
+          args: -exclude=G104,G306,G307 -tests=false -exclude-dir=doc/  ./...
+
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-latest
@@ -27,7 +43,7 @@ jobs:
       - name: Scan for Vulnerabilities in Code
         uses: Templum/govulncheck-action@v0.0.8
         with:
-          package: ./cmd/
+          package: cmd/...
           skip-upload: true
           fail-on-vuln: false
           vulncheck-version: latest


### PR DESCRIPTION
This PR creates a new CI step. It looks for known vulnerabilities in the [Go Vulnerability Database](https://pkg.go.dev/vuln/), reporting the vulnerability dependency and whether there is an available fix. 

Then, it uploads a SARIF report to [Github's code scanning API](https://docs.github.com/en/rest/code-scanning?apiVersion=2022-11-28).